### PR TITLE
Fix Transmit function to be able to send bytes in the emonHubOEMInterfacer format, allowing emonGLCD to work correctly with RFM69 packets

### DIFF
--- a/emonPiFrontEndCM.ino
+++ b/emonPiFrontEndCM.ino
@@ -40,8 +40,9 @@ emonhub.conf node decoder (assuming Node 5):
 
 #include <emonLibCM.h>                                                 // OEM CM library
 
-#include <emonEProm.h>
-// OEM EPROM library
+#include <emonEProm.h>                                                // OEM EPROM library
+
+#include <OneWire.h>
 
 // RFM interface
 #include "spi.h"                                                       // Requires "RFM69 Native" JeeLib Driver
@@ -52,10 +53,10 @@ bool rfDataAvailable = false;
 
 byte nativeMsg[66];                                                    // 'Native' format message buffer
 
-#define MAXMSG 66                                                      // Max length of o/g message
+#define MAXMSG 62                                                      // Max length of o/g message - payload can be 62 bytes max in RFM69
 char outmsg[MAXMSG];                                                   // outgoing message (to emonGLCD etc)
 byte outmsgLength;                                                     // length of message: non-zero length triggers transmission
-
+byte txDestId = 0 ;                                                    // 
 struct {                                                               // Ancilliary information
   byte srcNode = 0;
   byte msgLength = 0;
@@ -263,7 +264,7 @@ void loop()
 {
   if (digitalRead(shutdown_switch_pin) == 0 )
   {
-    digitalWrite(emonpi_GPIO_pin, HIGH);                               // if emonPi shutdown button pressed then send signal to the Pi on GPIO 11
+    //digitalWrite(emonpi_GPIO_pin, HIGH);                               // if emonPi shutdown button pressed then send signal to the Pi on GPIO 11
     shutdown_switch_last_state = true;
   }
   else
@@ -279,6 +280,12 @@ void loop()
 //-------------------------------------------------------------------------------------------------------------------------------------------
 
   int len = rf.receive(&nativeMsg, sizeof(nativeMsg));                 // Poll the RFM buffer and extract the data
+
+  if (len >0) {
+    Serial.print("got something len:");
+    Serial.println(len);
+  }
+
   if ((EEProm.rfOn & RFRX) && len > 1)
   {
     rfInfo.crc = true;
@@ -290,8 +297,7 @@ void loop()
     Serial.print(F("OK"));                                              // Bad packets (crc failure) are discarded by RFM69CW
     print_frame(rfInfo.msgLength);		                                  // Print received data
     double_LED_flash();
-  }
-  
+  } 
 //-------------------------------------------------------------------------------------------------------------------------------------------
 // RF Data handler - outbound ***************************************************************************************************************
 //-------------------------------------------------------------------------------------------------------------------------------------------
@@ -299,10 +305,8 @@ void loop()
 
 	if ((EEProm.rfOn & RFTX) && outmsgLength) {                           //if command 'outmsg' is waiting to be sent then let's send it
     digitalWrite(LEDpin, HIGH); delay(200); digitalWrite(LEDpin, LOW);
-    showString(PSTR(" -> "));
-    Serial.print((word) outmsgLength);
-    showString(PSTR(" b\n"));
-    rf.send(0, (void *)outmsg, outmsgLength);                          //  void RF69<SPI>::send (uint8_t header, const void* ptr, int len) {
+    Serial.print ("Sending ") ; Serial.print((word) outmsgLength); Serial.println(" bytes\n");
+    rf.send(txDestId, (void *)outmsg, outmsgLength);                    //  void RF69<SPI>::send (uint8_t header, const void* ptr, int len) {
     outmsgLength = 0;
 	}
 

--- a/emonPiFrontEndCM.ino
+++ b/emonPiFrontEndCM.ino
@@ -264,7 +264,7 @@ void loop()
 {
   if (digitalRead(shutdown_switch_pin) == 0 )
   {
-    //digitalWrite(emonpi_GPIO_pin, HIGH);                               // if emonPi shutdown button pressed then send signal to the Pi on GPIO 11
+    digitalWrite(emonpi_GPIO_pin, HIGH);                               // if emonPi shutdown button pressed then send signal to the Pi on GPIO 11
     shutdown_switch_last_state = true;
   }
   else
@@ -281,10 +281,6 @@ void loop()
 
   int len = rf.receive(&nativeMsg, sizeof(nativeMsg));                 // Poll the RFM buffer and extract the data
 
-  if (len >0) {
-    Serial.print("got something len:");
-    Serial.println(len);
-  }
 
   if ((EEProm.rfOn & RFRX) && len > 1)
   {
@@ -305,7 +301,7 @@ void loop()
 
 	if ((EEProm.rfOn & RFTX) && outmsgLength) {                           //if command 'outmsg' is waiting to be sent then let's send it
     digitalWrite(LEDpin, HIGH); delay(200); digitalWrite(LEDpin, LOW);
-    Serial.print ("Sending ") ; Serial.print((word) outmsgLength); Serial.println(" bytes\n");
+    Serial.print ("Sending ") ; Serial.print((word) outmsgLength); Serial.print(" bytes "); Serial.print("to node " ); Serial.println(txDestId) ;
     rf.send(txDestId, (void *)outmsg, outmsgLength);                    //  void RF69<SPI>::send (uint8_t header, const void* ptr, int len) {
     outmsgLength = 0;
 	}

--- a/emonPiFrontEndCM_config.ino
+++ b/emonPiFrontEndCM_config.ino
@@ -3,7 +3,7 @@
 
   Header for emonPi Continuous Monitoring - radio using JeeLib RFM69 "Native" format
 
-  
+
    ------------------------------------------
   Part of the openenergymonitor.org project
 
@@ -12,31 +12,31 @@
 
   Licence: GNU GPL V3
 
-V1.0.0   10/7/2021 Derived from emonLibCM examples and original emonPi sketch, that being derived from 
+  V1.0.0   10/7/2021 Derived from emonLibCM examples and original emonPi sketch, that being derived from
             https://github.com/openenergymonitor/emonpi/blob/master/Atmega328/emonPi_RFM69CW_RF12Demo_DiscreteSampling
             and emonLibCM example sketches, with config input based on emonTx V3 sketches.
 
 
-Config functions for emonPiCM
+  Config functions for emonPiCM
 
-EEPROM layout
+  EEPROM layout
 
-Byte
-0       RF Band
-1       Group
-2-5     vCal
-6-9     line frequency
-10-13   i1Cal
-14-17   i1Lead
-18-21   i2Cal
-22-25   i2Lead
-26-29   Datalogging period
-30      Pulses enabled
-31-34   Pulse min period
-35      Temperatures enabled
-36-83   Temperature Addresses (6×8)
-84      showCurrents print enabled
-85      rfOn
+  Byte
+  0       RF Band
+  1       Group
+  2-5     vCal
+  6-9     line frequency
+  10-13   i1Cal
+  14-17   i1Lead
+  18-21   i2Cal
+  22-25   i2Lead
+  26-29   Datalogging period
+  30      Pulses enabled
+  31-34   Pulse min period
+  35      Temperatures enabled
+  36-83   Temperature Addresses (6×8)
+  84      showCurrents print enabled
+  85      rfOn
 */
 
 
@@ -44,46 +44,46 @@ Byte
 #include <avr/pgmspace.h>
 #include <EEPROM.h>
 
- // Available Serial Commands
-const PROGMEM char helpText1[] =                                
-"|\n"
-"|Available commands:\n"
-"| l\t\t- list config (terse)\n"
-"| L\t\t- list config (verbose)\n"
-"| r\t\t- restore defaults & restart\n"
-"| s\t\t- save to EEPROM\n"
-"| v\t\t- show version\n"
-"| V<n>\t\t- verbose mode, 1 > ON, 0 > OFF\n"
-"| b<n>\t\t- set r.f. band n = 4 > 433MHz, 8 > 868MHz, 9 > 915MHz (may require hardware change)\n"
-"| p<nn>\t\t- set r.f. power. nn (0 - 31) = -18 dBm to +13 dBm. Default: 25 (+7 dBm)\n"
-"| g<nnn>\t- set Group (OEM default = 210)\n"
-"| n<nn>\t\t- set node ID (1..60)\n"
-"| c<n>\t\t- enable output for calibration. n = 0|1 \n"
-"| d<xx.x>\t- datalogging period (s)\n" 
-"| k<x> <yy.y> <zz.z>\n"
-"|\t\t- Calibrate input:\n"
-"|\t\t\tx = 0 > voltage, 1 > ct1, 2 > ct2, etc\n"
-"|\t\t\tyy.y = voltage/current calibration\n"
-"|\t\t\tzz.z = phase calibration. (ct only)\n"
-"|\t\t\te.g. k0 256.8\n"
-"|\t\t\tk1 90.9 2.00\n"
-"| f<xx>\t\t- frequency (50 or 60)\n"
-"| a<xx.x>\t- assumed voltage if no a.c. present\n"
-"| m<x> <yy>\t- meter pulse counting:\n"
-"|\t\t\tx = 0 > all OFF, x = 1 > count 1 ON, x = 2 > count 2 ON, <yy> = pulse minimum period (ms) (y is not needed when x = 0)\n"
-"| t0 <y>\t- temperature:\n"
-"|\t\t\ty = 0 > OFF, y = 1 > ON, Y = 2 > Search\n"
-"| t<x> <yy> <yy> <yy> <yy> <yy> <yy> <yy> <yy>\n"
-"|\t\t\tchange sensor's address or position:\n"
-"|\t\t\tx = the sensor position in the list (1-based)\n"
-"|\t\t\tyy = 8 hex bytes - the sensor's address\n"
-"|\t\t\te.g.  28 81 43 31 07 00 00 D9\n"
-"|\t\t\tN.B. Sensors CANNOT be added beyond the array size.\n"
-"| T<ccc>\\n\t- transmit a string.\n"  
-"| w<n>\t\t- n = 0 > radio OFF, n = 1 for Receive ON, n = 2 for Transmit ON, n = 3 for both ON\n" 
-"| z\t\t- set the energy values and pulse count(s) to zero\n" 
-"| ?\t\t- show this again\n|"
-;
+// Available Serial Commands
+const PROGMEM char helpText1[] =
+  "|\n"
+  "|Available commands:\n"
+  "| l\t\t- list config (terse)\n"
+  "| L\t\t- list config (verbose)\n"
+  "| r\t\t- restore defaults & restart\n"
+  "| s\t\t- save to EEPROM\n"
+  "| v\t\t- show version\n"
+  "| V<n>\t\t- verbose mode, 1 > ON, 0 > OFF\n"
+  "| b<n>\t\t- set r.f. band n = 4 > 433MHz, 8 > 868MHz, 9 > 915MHz (may require hardware change)\n"
+  "| p<nn>\t\t- set r.f. power. nn (0 - 31) = -18 dBm to +13 dBm. Default: 25 (+7 dBm)\n"
+  "| g<nnn>\t- set Group (OEM default = 210)\n"
+  "| n<nn>\t\t- set node ID (1..60)\n"
+  "| c<n>\t\t- enable output for calibration. n = 0|1 \n"
+  "| d<xx.x>\t- datalogging period (s)\n"
+  "| k<x> <yy.y> <zz.z>\n"
+  "|\t\t- Calibrate input:\n"
+  "|\t\t\tx = 0 > voltage, 1 > ct1, 2 > ct2, etc\n"
+  "|\t\t\tyy.y = voltage/current calibration\n"
+  "|\t\t\tzz.z = phase calibration. (ct only)\n"
+  "|\t\t\te.g. k0 256.8\n"
+  "|\t\t\tk1 90.9 2.00\n"
+  "| f<xx>\t\t- frequency (50 or 60)\n"
+  "| a<xx.x>\t- assumed voltage if no a.c. present\n"
+  "| m<x> <yy>\t- meter pulse counting:\n"
+  "|\t\t\tx = 0 > all OFF, x = 1 > count 1 ON, x = 2 > count 2 ON, <yy> = pulse minimum period (ms) (y is not needed when x = 0)\n"
+  "| t0 <y>\t- temperature:\n"
+  "|\t\t\ty = 0 > OFF, y = 1 > ON, Y = 2 > Search\n"
+  "| t<x> <yy> <yy> <yy> <yy> <yy> <yy> <yy> <yy>\n"
+  "|\t\t\tchange sensor's address or position:\n"
+  "|\t\t\tx = the sensor position in the list (1-based)\n"
+  "|\t\t\tyy = 8 hex bytes - the sensor's address\n"
+  "|\t\t\te.g.  28 81 43 31 07 00 00 D9\n"
+  "|\t\t\tN.B. Sensors CANNOT be added beyond the array size.\n"
+  "| T<ccc>\\n\t- transmit a string.\n"
+  "| w<n>\t\t- n = 0 > radio OFF, n = 1 for Receive ON, n = 2 for Transmit ON, n = 3 for both ON\n"
+  "| z\t\t- set the energy values and pulse count(s) to zero\n"
+  "| ?\t\t- show this again\n|"
+  ;
 
 
 extern DeviceAddress *temperatureSensors;
@@ -97,19 +97,19 @@ static void load_config(void)
 
 static void list_calibration(void)
 {
-  
+
   Serial.println(F("|Settings"));
   Serial.print(F("|Radio: ")); Serial.println(EEProm.rfOn);
   Serial.print(F("|RF Band: "));
   if (EEProm.RF_freq == RFM_433MHZ) Serial.println(F("433MHz"));
   if (EEProm.RF_freq == RFM_868MHZ) Serial.println(F("868MHz"));
-  if (EEProm.RF_freq == RFM_915MHZ) Serial.println(F("915MHz")); 
-  Serial.print(F("|Power: "));Serial.print(EEProm.rfPower - 18);Serial.println(F(" dBm"));
+  if (EEProm.RF_freq == RFM_915MHZ) Serial.println(F("915MHz"));
+  Serial.print(F("|Power: ")); Serial.print(EEProm.rfPower - 18); Serial.println(F(" dBm"));
   Serial.print(F("|Group: ")); Serial.println(EEProm.networkGroup);
   Serial.print(F("|Node ID: ")); Serial.println(EEProm.nodeID);
   Serial.println(F("|Calibration"));
   Serial.print(F("|assumedV: ")); Serial.println(EEProm.assumedVrms);
-  Serial.print(F("|AC Detected: ")); Serial.println(EmonLibCM_acPresent()?"Yes":"No");
+  Serial.print(F("|AC Detected: ")); Serial.println(EmonLibCM_acPresent() ? "Yes" : "No");
   Serial.print(F("|freq: ")); Serial.println(EEProm.lineFreq);
   Serial.print(F("|vCal: ")); Serial.println(EEProm.vCal);
   Serial.print(F("|i1Cal: ")); Serial.print(EEProm.i1Cal);
@@ -134,7 +134,7 @@ static void report_calibration(void)
   Serial.print(F(" b"));
   if (EEProm.RF_freq == RFM_433MHZ) Serial.print(F("4"));
   if (EEProm.RF_freq == RFM_868MHZ) Serial.print(F("8"));
-  if (EEProm.RF_freq == RFM_915MHZ) Serial.print(F("9")); 
+  if (EEProm.RF_freq == RFM_915MHZ) Serial.print(F("9"));
   Serial.print(F(" p")); Serial.print(EEProm.rfPower);
   Serial.print(F(" g")); Serial.print(EEProm.networkGroup);
   Serial.print(F(" i")); Serial.print(EEProm.nodeID);
@@ -166,7 +166,7 @@ static void wipe_eeprom(void)
   {
     Serial.print(F("|Resetting..."));
   }
-  eepromHide(eepromSig);   
+  eepromHide(eepromSig);
   if (verbose)
   {
     Serial.println(F("|Sketch restarting with default config."));
@@ -180,38 +180,38 @@ void softReset(void)
 
 void getCalibration(void)
 {
-/*
- * Reads calibration information (if available) from the serial port at runtime. 
- * Data is expected generally in the format
- * 
- *  [l] [x] [y] [z]
- * 
- * where:
- *  [l] = a single letter denoting the variable to adjust
- *  [x] [y] [z] are values to be set.
- *  see the user instruction above, the comments below or the separate documentation for details
- * 
- */
+  /*
+     Reads calibration information (if available) from the serial port at runtime.
+     Data is expected generally in the format
 
-	if (Serial.available())
-  {   
-    int k1; 
-    double k2, k3; 
+      [l] [x] [y] [z]
+
+     where:
+      [l] = a single letter denoting the variable to adjust
+      [x] [y] [z] are values to be set.
+      see the user instruction above, the comments below or the separate documentation for details
+
+  */
+
+  if (Serial.available())
+  {
+    int k1;
+    double k2, k3;
     char c = Serial.peek();
     char* msg;
-    
+
     if (!lockout(c))
       switch (c) {
-        
+
         case 'a':
           EEProm.assumedVrms = Serial.parseFloat();
-          EmonLibCM_setAssumedVrms(EEProm.assumedVrms);            
+          EmonLibCM_setAssumedVrms(EEProm.assumedVrms);
           if (verbose)
           {
-            Serial.print(F("|Assumed V: "));Serial.println(EEProm.assumedVrms);
+            Serial.print(F("|Assumed V: ")); Serial.println(EEProm.assumedVrms);
           }
           break;
-          
+
         case 'b':  // set band: 4 = 433, 8 = 868, 9 = 915
           EEProm.RF_freq = bandToFreq(Serial.parseInt());
           if (verbose)
@@ -226,7 +226,7 @@ void getCalibration(void)
 
         case 'c':
           /*
-          * Format expected: c0 | c1
+            Format expected: c0 | c1
           */
           k1 = Serial.parseInt();
           switch (k1) {
@@ -235,27 +235,27 @@ void getCalibration(void)
             default: EEProm.showCurrents = false;
           }
           break;
-        
+
         case 'd':
           /*  Format expected: p[x]
-           * 
-           * where:
-           *  [x] = a floating point number for the datalogging period in s
-           */
-          k2 = Serial.parseFloat(); 
+
+             where:
+              [x] = a floating point number for the datalogging period in s
+          */
+          k2 = Serial.parseFloat();
           if (k2 < 0.1)
             k2 = 0.1;
-          EmonLibCM_datalog_period(k2); 
+          EmonLibCM_datalog_period(k2);
           EEProm.period = k2;
           if (verbose)
           {
-            Serial.print(F("|datalog period ")); Serial.print(k2);Serial.println(F(" s"));
+            Serial.print(F("|datalog period ")); Serial.print(k2); Serial.println(F(" s"));
           }
           break;
-          
+
         case 'f':
           /*
-          *  Format expected: f50 | f60
+             Format expected: f50 | f60
           */
           k1 = Serial.parseFloat();
           EEProm.lineFreq = k1;
@@ -264,7 +264,7 @@ void getCalibration(void)
             Serial.print(F("|freq ")); Serial.println(EEProm.lineFreq);
           }
           break;
-          
+
         case 'g':  // set network group
           EEProm.networkGroup = Serial.parseInt();
           if (verbose)
@@ -276,30 +276,30 @@ void getCalibration(void)
 
         case 'k':
           /*  Format expected: k[x] [y] [z]
-          * 
-          * where:
-          *  [x] = a single numeral: 0 = voltage calibration, 1 = ct1 calibration, 2 = ct2 calibration, etc
-          *  [y] = a floating point number for the voltage/current calibration constant
-          *  [z] = a floating point number for the phase calibration for this c.t. (z is not needed, or ignored if supplied, when x = 0)
-          * 
-          * e.g. k0 256.8
-          *      k1 90.9 1.7 
-          * 
-          * If power factor is not displayed, it is impossible to calibrate for phase errors,
-          *  and the standard value of phase calibration MUST BE SENT when a current calibration is changed.
+
+            where:
+             [x] = a single numeral: 0 = voltage calibration, 1 = ct1 calibration, 2 = ct2 calibration, etc
+             [y] = a floating point number for the voltage/current calibration constant
+             [z] = a floating point number for the phase calibration for this c.t. (z is not needed, or ignored if supplied, when x = 0)
+
+            e.g. k0 256.8
+                 k1 90.9 1.7
+
+            If power factor is not displayed, it is impossible to calibrate for phase errors,
+             and the standard value of phase calibration MUST BE SENT when a current calibration is changed.
           */
-          k1 = Serial.parseInt(); 
-          k2 = Serial.parseFloat(); 
-          k3 = Serial.parseFloat(); 
+          k1 = Serial.parseInt();
+          k2 = Serial.parseFloat();
+          k3 = Serial.parseFloat();
           while (Serial.available())
-            Serial.read(); 
-                
+            Serial.read();
+
           // Write the values back as Globals, re-calculate intermediate values.
           switch (k1) {
             case 0 : EmonLibCM_ReCalibrate_VChannel(k2);
               EEProm.vCal = k2;
               break;
-                
+
             case 1 : EmonLibCM_ReCalibrate_IChannel(1, k2, k3);
               EEProm.i1Cal = k2;
               EEProm.i1Lead = k3;
@@ -314,29 +314,29 @@ void getCalibration(void)
           }
           if (verbose)
           {
-            Serial.print(F("|k"));Serial.print(k1);Serial.print(F(" "));Serial.print(k2);Serial.print(F(" "));Serial.println(k3);
+            Serial.print(F("|k")); Serial.print(k1); Serial.print(F(" ")); Serial.print(k2); Serial.print(F(" ")); Serial.println(k3);
           }
           break;
-            
+
         case 'L':
           list_calibration(); // print the calibration values (verbose)
           break;
-            
+
         case 'l':
           report_calibration(); // report calibration values to emonHub (terse)
           break;
-            
+
         case 'm' :
           /*  Format expected: m[x] [y]
-           * 
-           * where:
-           *  [x] = a single numeral: 0 = pulses OFF, 1 = pulses 1 ON, 2 = pulses 2 ON
-           *  [y] = an integer for the pulse min period in ms - ignored when x=0
-           */
-          k1 = Serial.parseInt(); 
-          k2 = Serial.parseInt(); 
+
+             where:
+              [x] = a single numeral: 0 = pulses OFF, 1 = pulses 1 ON, 2 = pulses 2 ON
+              [y] = an integer for the pulse min period in ms - ignored when x=0
+          */
+          k1 = Serial.parseInt();
+          k2 = Serial.parseInt();
           while (Serial.available())
-            Serial.read(); 
+            Serial.read();
 
           switch (k1) {
             case 0 : EmonLibCM_setPulseEnable(0, false);
@@ -344,15 +344,15 @@ void getCalibration(void)
               EmonLibCM_setPulseEnable(1, false);
               EEProm.pulse2_enable = false;
               break;
-            
+
             case 1 : EmonLibCM_setPulseMinPeriod(0, k2);
               EmonLibCM_setPulseEnable(true);
               EEProm.pulse_enable = true;
               EEProm.pulse_period = k2;
               break;
-            
+
             case 2 : EmonLibCM_setPulseMinPeriod(1, k2);
-              EmonLibCM_setPulseEnable(2,true);
+              EmonLibCM_setPulseEnable(2, true);
               EEProm.pulse2_enable = true;
               EEProm.pulse2_period = k2;
               break;
@@ -361,22 +361,22 @@ void getCalibration(void)
           {
             Serial.print(F("|Pulses: "));
             switch (k1) {
-              case 0 : Serial.println(F("off")); 
+              case 0 : Serial.println(F("off"));
                 break;
-              
+
               case 1 : Serial.print(F("Ch 1: "));
                 Serial.print(k2);
                 Serial.println(F(" ms"));
                 break;
-              
+
               case 2 : Serial.print(F("Ch 2: "));
                 Serial.print(k2);
                 Serial.println(F(" ms"));
                 break;
             }
           }
-          break;        
-    
+          break;
+
         case 'n':
         case 'i':  //  Set NodeID - range expected: 1 - 60
           EEProm.nodeID = Serial.parseInt();
@@ -392,10 +392,10 @@ void getCalibration(void)
           EEProm.rfPower = (Serial.parseInt() & 0x1F);
           if (verbose)
           {
-            Serial.print(F("|p: "));Serial.print((EEProm.rfPower & 0x1F) - 18);Serial.println(F(" dBm"));
+            Serial.print(F("|p: ")); Serial.print((EEProm.rfPower & 0x1F) - 18); Serial.println(F(" dBm"));
           }
           rfChanged = true;
-          break; 
+          break;
 
         case 'r':
           wipe_eeprom(); // restore sketch defaults
@@ -405,58 +405,75 @@ void getCalibration(void)
         case 's' :
           save_config(); // Save to EEPROM. ATMega328p has 1kB  EEPROM
           break;
-            
+
         case 't' :
           /*  Format expected: t[x] [y] [y] ...
-           */
+          */
           set_temperatures();
           break;
 
         case 'T': // write alpha-numeric string to be transmitted.
-          msg = outmsg;
-          {
-            char c = 0;
-            Serial.read();  // discard 'w'
-            while (c != '\n' && outmsgLength < MAXMSG)
-            {
-              c = Serial.read();
-              if (c > 31 && c < 127)
-              {
-                *msg++ = c;
+          outmsgLength = 0;
+          char c = 0;
+
+          while (Serial.peek() ) {
+            long txDataByte = Serial.parseInt();
+            if (txDataByte > 255 || txDataByte < 0) {
+              Serial.println("Tx Data invalid.. each byte must be between 0 & 255");
+              Serial.println("Usage:T byte1,byte2,byteN,dest_node_id, Max number of bytes = 60");
+              outmsgLength = 0 ;        //make sure invalid data not sent
+              break;
+            } else if (Serial.peek() == -1 && txDataByte == 0) {
+              //done, got all the bytes from Serial
+              if (outmsgLength != 0)
+                 outmsgLength-- ;      //the actual length of the msg is 1 less as the 1st byte received is not part of the payload
+              break ;
+
+            } else {
+              Serial.print("read:") ;
+              Serial.println(txDataByte) ;
+              if (outmsgLength == 0) {
+                //first byte should be the destination ID, 0 for broadcast
+                //This doesn't become part of the message
+                txDestId = txDataByte ;
+                outmsgLength++ ;
+              } else {
+                outmsg[outmsgLength - 1] = txDataByte ; //the outmsg index is always -1 due to the destID not being part of outmsg
                 outmsgLength++;
               }
             }
-          }          
+          }
+          Serial.print ("Queueing  ") ; Serial.print(outmsgLength); Serial.print (" bytes to send to node ") ; Serial.println (txDestId);
           break;
-        
+
         case 'v': // print firmware version
           Serial.print(F("|emonPi CM V")); printVersion();
           break;
 
         case 'V': // Verbose mode
           /*
-          * Format expected: V0 | V1
+            Format expected: V0 | V1
           */
-          verbose = (bool)Serial.parseInt();    
-          Serial.print(F("|Verbose mode "));Serial.println(verbose?F("on"):F("off"));
-         break;
-          
+          verbose = (bool)Serial.parseInt();
+          Serial.print(F("|Verbose mode ")); Serial.println(verbose ? F("on") : F("off"));
+          break;
+
         case 'w':
           /*
-          * Wireless off = 0, tx = 1, rx = 2, tx+rx  = 3
-          * Format expected: w0 - w3 
+            Wireless off = 0, tx = 1, rx = 2, tx+rx  = 3
+            Format expected: w0 - w3
           */
           EEProm.rfOn = Serial.parseInt();
           if (verbose)
           {
-            Serial.print(F("|Radio "));;Serial.println(EEProm.rfOn);
+            Serial.print(F("|Radio "));; Serial.println(EEProm.rfOn);
           }
           break;
 
         case 'z':
-        /*
-        * Zero all energy values
-        */
+          /*
+            Zero all energy values
+          */
           zeroEValues();
           EmonLibCM_setWattHour(0, 0);
           EmonLibCM_setWattHour(1, 0);
@@ -464,8 +481,8 @@ void getCalibration(void)
           EmonLibCM_setPulseCount(1, 0);
           break;
 
-        
-        case '?':  // show Help text        
+
+        case '?':  // show Help text
           showString(helpText1);
           Serial.println();
           break;
@@ -473,9 +490,9 @@ void getCalibration(void)
         default:
           ;
       }
-      // flush the input buffer
-      while (Serial.available())
-        Serial.read();
+    // flush the input buffer
+    while (Serial.available())
+      Serial.read();
   }
 }
 
@@ -483,7 +500,7 @@ bool lockout(char c)
 {
   static bool locked = false;
   static unsigned long locktime;
-  
+
   if (c > 47 && c < 58)                                                // lock out old 'Reverse Polish' format: numbers first.
   {
     locked = true;
@@ -496,15 +513,25 @@ bool lockout(char c)
     locked = false;
   }
   return locked;
-}  
-  
-static byte bandToFreq (byte band) {
-  return band == 4 ? RFM_433MHZ : band == 8 ? RFM_868MHZ : band == 9 ? RFM_915MHZ : 0;
 }
 
-static void showString (PGM_P s) 
+static byte bandToFreq (int band) {
+
+  if (band == 4 || band == 433) {
+    return RFM_433MHZ ;
+  } else if (band == 8 || band == 868) {
+    return RFM_868MHZ ;
+  } else if (band == 9 || band == 915) {
+    return RFM_915MHZ ;
+  } else {
+    return 0 ;
+  }
+
+}
+
+static void showString (PGM_P s)
 {
-  for (;;) 
+  for (;;)
   {
     char c = pgm_read_byte(s++);
     if (c == 0)
@@ -518,20 +545,20 @@ static void showString (PGM_P s)
 void set_temperatures(void)
 {
   /*  Format expected: t[x] [y] [y] ...
-  * 
-  * where:
-  *  [x] = 0  [y] = single numeral: 0 = temperature measurement OFF, 1 = temperature measurement ON, 2 = search
-  *  [x] = a single numeral > 0: the position of the sensor in the list (1-based)
-  *  [y] = 8 hexadecimal bytes representing the sensor's address
-  *          e.g. t2 28 81 43 31 07 00 00 D9
+
+    where:
+     [x] = 0  [y] = single numeral: 0 = temperature measurement OFF, 1 = temperature measurement ON, 2 = search
+     [x] = a single numeral > 0: the position of the sensor in the list (1-based)
+     [y] = 8 hexadecimal bytes representing the sensor's address
+             e.g. t2 28 81 43 31 07 00 00 D9
   */
-    
+
   DeviceAddress sensorAddress;
-         
-	int k1 = Serial.parseInt();
+
+  int k1 = Serial.parseInt();
 
   if (k1 == 0)
-  { 
+  {
     byte k2 = Serial.parseInt();
     // write to EEPROM
     switch (k2) {
@@ -552,35 +579,35 @@ void set_temperatures(void)
   else
   {
     byte i = 0, a = 0, b;
-    Serial.readBytes(&b,1);     // expect a leading space
-    while (Serial.readBytes(&b,1) && i < 8)
-    {            
+    Serial.readBytes(&b, 1);    // expect a leading space
+    while (Serial.readBytes(&b, 1) && i < 8)
+    {
       if (b == ' ' || b == '\r' || b == '\n')
       {
         sensorAddress[i++] = a;
         a = 0;
-      }                
+      }
       else
       {
         a *= 16;
         a += c2h(b);
-      }          
-    }     
+      }
+    }
     // set address
-    for (byte i=0; i<8; i++)
-      EEProm.allAddresses[k1-1][i] = sensorAddress[i];
+    for (byte i = 0; i < 8; i++)
+      EEProm.allAddresses[k1 - 1][i] = sensorAddress[i];
   }
-	while (Serial.available())
-		Serial.read(); 
+  while (Serial.available())
+    Serial.read();
 }
 
 byte c2h(byte b)
 {
-  if (b > 47 && b < 58) 
+  if (b > 47 && b < 58)
     return b - 48;
-  else if (b > 64 && b < 71) 
+  else if (b > 64 && b < 71)
     return b - 55;
-  else if (b > 96 && b < 103) 
+  else if (b > 96 && b < 103)
     return b - 87;
   return 0;
 }


### PR DESCRIPTION
This allows emonGLCD to work correctly with RFM69 packets and puts the transmit function to byte sending as per previous firmwares.
Latest emonGLCD firmware that supports this is here (pull request to come)

https://github.com/alandpearson/EmonGLCD/tree/datetime/firmware/SolarPV_rfm69

Separate pull requests have been submitted to emonhub base fixing TX in both emonHubOEMInterfacer and emonHubJeeNodeInterfacer after the python rebase.

Bring these pull requests together will restore Tx in the emonhub codebase (again).
